### PR TITLE
Issue #16 - Add a script to prefill title, breakage, platform sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 # Build output from the kbcheck tool
 target/
+
+.mypy_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.961
+    hooks:
+      - id: mypy
+        name: mypy-kb
+        files: ^tools/scripts/
+        entry: mypy tools/scripts/
+        pass_filenames: false
+        additional_dependencies:
+          - types-python-slugify==6.1.0
+          - types-PyYAML==6.0.9
+          - types-requests==2.28.0
+          - types-urllib3==1.26.15

--- a/README.md
+++ b/README.md
@@ -11,20 +11,7 @@ Please note that this is still an early **work in progress**, and everything in 
 ## Additional information
 
 - [Criteria for the `severity` and `user_base_impact` fields](./docs/severity-and-impact.md).
-
-## Script to create yml file for a given bugzilla bug
-
-The script will create a file in the `data` directory and prefill title, breakage reports from webcompat and fenix repository and
-platform links (the original bugzilla bug and any others from bugs.chromium.org or bugs.webkit.org).
-
-It can be run the following way:
-
-```
-python3 -m venv env
-source env/bin/activate
-pip install -r requirements.txt
-python3 ./tools/scripts/generate.py --bug_id=<bug_id>
-```
+- [Script to generate a yml file for a provided bugzilla bug](./docs/generate-yml.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ Please note that this is still an early **work in progress**, and everything in 
 
 - [Criteria for the `severity` and `user_base_impact` fields](./docs/severity-and-impact.md).
 
+## Script to create yml file for a given bugzilla bug
+
+The script will create a file in the `data` directory and prefill title, breakage reports from webcompat and fenix repository and
+platform links (the original bugzilla bug and any others from bugs.chromium.org or bugs.webkit.org).
+
+It can be run the following way:
+
+```
+python3 -m venv env
+source env/bin/activate
+pip install -r requirements.txt
+python3 ./tools/scripts/generate.py --bug_id=<bug_id>
+```
+
 ## License
 
 [Creative Commons Public Domain Dedication (CC0 1.0)](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/docs/generate-yml.md
+++ b/docs/generate-yml.md
@@ -1,0 +1,13 @@
+# Script to generate a yml file for a provided bugzilla bug
+
+The script will generate a yml file in the `data` directory and prefill title, breakage reports from webcompat and fenix repository, as well as
+platform links (the original bugzilla bug and any others from bugs.chromium.org or bugs.webkit.org).
+
+It can be run the following way:
+
+```
+python3 -m venv env
+source env/bin/activate
+pip install -r requirements.txt
+python3 ./tools/scripts/generate.py --bug_id=<bug_id>
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+mypy==0.961
+pre-commit==2.19.0
 python-slugify==6.1.2
 pyyaml==6.0.0
 requests==2.28.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+python-slugify==6.1.2
+pyyaml==6.0.0
+requests==2.28.0

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -1,0 +1,86 @@
+import requests
+import argparse
+import yaml
+import os
+from slugify import slugify
+
+cwd = os.getcwd()
+DATA_PATH = os.path.join(cwd, 'data')
+
+BUGZILLA_URL = "https://bugzilla.mozilla.org/show_bug.cgi?id="
+BUGZILLA_API = "https://bugzilla.mozilla.org/rest/bug/"
+
+BREAKAGE_STR = ["webcompat", "mozilla-mobile"]
+PLATFORM_STR = ["bugs.chromium.org", "bugs.webkit.org"]
+
+
+def fetch_bug_by_id(bug_id) -> dict:
+    url = BUGZILLA_API + bug_id
+    params = {"include_fields": "summary,see_also"}
+    response = requests.get(url, params=params)
+    response.raise_for_status()
+    result = response.json()
+    return result["bugs"][0]
+
+
+def split_see_also_by_type(see_also_list, bug_id) -> list:
+    lists = {
+        "breakage": [f"{BUGZILLA_URL}{bug_id}#c0"],
+        "platform": [BUGZILLA_URL + bug_id]
+    }
+
+    for item in see_also_list:
+        if any(bs in item for bs in BREAKAGE_STR):
+            lists["breakage"].append(item)
+
+        if any(ps in item for ps in PLATFORM_STR):
+            lists["platform"].append(item)
+
+    return lists
+
+
+def build_obj(bug_id) -> dict:
+    bug = fetch_bug_by_id(bug_id)
+    lists = split_see_also_by_type(bug["see_also"], bug_id)
+    data = {
+        "title": bug["summary"],
+        "references": {
+            "breakage": lists["breakage"],
+            "platform_issues": lists["platform"]
+        }
+    }
+
+    return data
+
+
+def build_yml(bug_id) -> None:
+    data = build_obj(bug_id)
+    title = data["title"]
+    filename = slugify(title, max_length=40, word_boundary=True, save_order=True)
+    path = f"{DATA_PATH}/{filename}.yml"
+
+    if os.path.exists(path):
+        print(f"A knowledge base entry for this bug already exists. Please delete `{path}` file and try again.")
+        return
+    else:
+        with open(path, 'w') as f:
+            yaml.dump(data, f, sort_keys=False, default_flow_style=False)
+            print(f"A yml file was created for bug {bug_id}: {title}")
+
+
+def main() -> None:
+    description = "Prefill yaml file with bugzilla bug data for knowledge base."
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
+        "--bug_id",
+        help="Bugzilla bug id.",
+        type=str,
+        required=True,
+    )
+
+    args = parser.parse_args()
+    build_yml(args.bug_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is a helper script that could be useful for bugs like https://bugzilla.mozilla.org/show_bug.cgi?id=390936 with lots of breakage reports.

It can be run the following way:

```
python3 -m venv env
source env/bin/activate
pip install -r requirements.txt
python3 ./scripts/generate.py --bug_id=390936
```
It does the following:
- Creates a yml file in the data directory
- Prefills:
      -    title
      -    breakage reports from webcompat and fenix repository
      -    platform links (the original bugzilla bug and any others from bugs.chromium.org or bugs.webkit.org)

It doesn't add bugs from `duplicates` field or other bugzilla issues that linked in the `see also` field yet, so this needs to be done manually for now.
