### PR TITLE
Improve validator logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,8 +411,10 @@ name = "kbcheck"
 version = "0.1.0"
 dependencies = [
  "jsonschema",
+ "serde",
  "serde_json",
  "serde_yaml",
+ "url",
  "walkdir",
 ]
 
@@ -1036,6 +1038,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/tools/kbcheck/Cargo.toml
+++ b/tools/kbcheck/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [dependencies]
 jsonschema="0.16"
+serde="1"
 serde_json="1"
 serde_yaml="0.8"
 walkdir = "2"
+url={ version = "2", features = ["serde"] }

--- a/tools/kbcheck/src/entry.rs
+++ b/tools/kbcheck/src/entry.rs
@@ -1,0 +1,61 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Severity {
+    Critical,
+    High,
+    Normal,
+    Low,
+}
+
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum UserBaseImpact {
+    Large,
+    Medium,
+    Small,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct Solutions {
+    #[serde(default)]
+    interventions: Vec<Url>,
+    #[serde(default)]
+    notes: Vec<String>,
+    #[serde(default)]
+    workarounds: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct References {
+    #[serde(default)]
+    pub breakage: Vec<Url>,
+    #[serde(default)]
+    pub platform_issues: Vec<Url>,
+    #[serde(default)]
+    pub telemetry: Vec<Url>,
+    #[serde(default)]
+    pub testcases: Vec<String>, // TODO: how to handle relative URLs?
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Entry {
+    pub title: String,
+    pub severity: Severity,
+    pub user_base_impact: Option<UserBaseImpact>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub symptoms: Vec<String>,
+    #[serde(default)]
+    pub console_messages: Vec<String>,
+    #[serde(default)]
+    pub solutions: Solutions,
+    #[serde(default)]
+    pub references: References,
+}

--- a/tools/kbcheck/src/main.rs
+++ b/tools/kbcheck/src/main.rs
@@ -1,9 +1,45 @@
+mod entry;
+
+use entry::Entry;
 use jsonschema::JSONSchema;
+use serde::de::{Deserialize, IntoDeserializer};
+use std::collections::BTreeMap;
 use std::error::Error;
-use std::fs::File;
+use std::fmt::Display;
+use std::fs::{self, File};
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
+use url::Url;
 use walkdir::WalkDir;
+
+type EntriesMap = BTreeMap<PathBuf, Entry>;
+type Errors = Vec<ValidationError>;
+
+/// Representation of an error in a data file that causes it to fail validation
+struct ValidationError {
+    path: PathBuf,
+    line: Option<usize>,
+    message: String,
+}
+
+impl ValidationError {
+    fn new(path: &Path, line: Option<usize>, message: String) -> ValidationError {
+        ValidationError {
+            path: path.to_path_buf(),
+            line,
+            message,
+        }
+    }
+}
+
+impl Display for ValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.line {
+            Some(line) => write!(f, "{}:{} - {}", self.path.display(), line, self.message),
+            None => write!(f, "{} - {}", self.path.display(), self.message),
+        }
+    }
+}
 
 fn read_json(path: &Path) -> Result<serde_json::Value, Box<dyn Error>> {
     let file = File::open(path)?;
@@ -11,42 +47,140 @@ fn read_json(path: &Path) -> Result<serde_json::Value, Box<dyn Error>> {
     Ok(serde_json::from_reader(reader)?)
 }
 
-fn read_yaml_as_json(path: &Path) -> Result<serde_json::Value, Box<dyn Error>> {
-    let file = File::open(path)?;
-    let reader = BufReader::new(file);
-    let value: serde_json::Value = serde_yaml::from_reader(reader)?;
-    Ok(value)
+/// Validate the contents of the string data of a file.
+/// This can check for purely textual errors like trailing whitespace
+fn validate_file_as_string(path: &Path, data: &str, errors: &mut Errors) {
+    for (i, line) in data.lines().enumerate() {
+        // Check trailing whitespace
+        if line.ends_with(|c: char| c.is_ascii_whitespace()) {
+            errors.push(ValidationError::new(
+                path,
+                Some(i),
+                "trailing whitespace".into(),
+            ));
+        }
+    }
 }
 
-fn validate(root_path: &Path) -> Result<Vec<String>, Box<dyn Error>> {
-    let mut errors: Vec<String> = Vec::new();
+/// Load each data file and perform per-file validation For files that
+/// could be successfully parsed, this returns an Entry object. In all
+/// cases it returns a list of validation errors.  Note that in the
+/// case that the file can be parsed despite a validation error, we
+/// return the Entry object for further processing.
+fn load_and_validate_file(
+    schema: &JSONSchema,
+    path: &Path,
+) -> Result<(Option<Entry>, Errors), Box<dyn Error>> {
+    println!("Loading {}", path.display());
+    let mut errors = Vec::new();
+
+    let maybe_file_string = fs::read_to_string(path);
+    if let Err(error) = maybe_file_string {
+        errors.push(ValidationError::new(path, None, error.to_string()));
+        return Ok((None, errors));
+    };
+
+    let file_string = maybe_file_string.expect("Should be able to unwrap Ok value");
+
+    validate_file_as_string(path, &file_string, &mut errors);
+
+    let maybe_json_value: Result<serde_json::Value, _> = serde_yaml::from_str(&file_string);
+    if let Err(error) = maybe_json_value {
+        errors.push(ValidationError::new(path, None, error.to_string()));
+        return Ok((None, errors));
+    };
+
+    let json_value = maybe_json_value.expect("Should be able to unwrap Ok value");
+
+    if let Err(file_errors) = schema.validate(&json_value) {
+        for error in file_errors {
+            errors.push(ValidationError::new(path, None, error.to_string()));
+        }
+        return Ok((None, errors));
+    };
+
+    // Convert the JSON Value into an Entry object and add it to the map
+    match Entry::deserialize(json_value.into_deserializer()) {
+        Ok(entry) => Ok((Some(entry), errors)),
+        Err(error) => {
+            errors.push(ValidationError::new(path, None, error.to_string()));
+            Ok((None, errors))
+        }
+    }
+}
+
+/// Load all the data files, validate each individual file, and return
+/// a map between a PathBuf and the Entry object for that file, along
+/// with a list of validation errors.
+fn load_and_validate_files(root_path: &Path) -> Result<(EntriesMap, Errors), Box<dyn Error>> {
     let schema_path = root_path
         .to_owned()
         .join(PathBuf::from("schemas/entry.schema.json"));
     let data_path = root_path.to_owned().join("data");
     let schema_json = read_json(&schema_path)?;
     let schema = JSONSchema::compile(&schema_json).unwrap();
+
+    let mut entries: EntriesMap = BTreeMap::new();
+    let mut errors = Vec::new();
+
     for maybe_entry in WalkDir::new(&data_path) {
         let entry = maybe_entry?;
         let path = entry.path();
         let ext = path.extension().unwrap_or_default();
         if ext == "yml" || ext == "yaml" {
-            println!("Validating {}", path.display());
-            match read_yaml_as_json(path) {
-                Ok(json_data) => {
-                    let result = schema.validate(&json_data);
-                    if let Err(file_errors) = result {
-                        for error in file_errors {
-                            errors.push(format!("{}: {}", path.display(), error));
-                        }
-                    };
+            let (maybe_entry, file_errors) = load_and_validate_file(&schema, path)?;
+            if let Some(entry) = maybe_entry {
+                entries.insert(path.to_path_buf(), entry);
+            }
+            errors.extend(file_errors.into_iter())
+        }
+    }
+    Ok((entries, errors))
+}
+
+/// Validate that more than one file doesn't correspond to the same platform issue.
+/// This is highly suggestive that the issues should be merged or the bugs split
+fn validate_unique_platform_issues(entries: &EntriesMap) -> Errors {
+    let mut errors = Vec::new();
+    let mut seen_issues: BTreeMap<Url, &Path> = BTreeMap::new();
+    for (path, entry) in entries.iter() {
+        for issue_url in entry.references.platform_issues.iter() {
+            let mut resource_url = issue_url.clone();
+            resource_url.set_fragment(None);
+            match seen_issues.get(&resource_url) {
+                Some(first_path) => {
+                    errors.push(ValidationError::new(
+                        path,
+                        None,
+                        format!(
+                            "Duplicate issue URL {} first seen in {}",
+                            resource_url,
+                            first_path.display()
+                        ),
+                    ));
                 }
-                Err(err) => {
-                    errors.push(err.to_string());
+                None => {
+                    seen_issues.insert(resource_url, path);
                 }
             }
         }
     }
+    errors
+}
+
+/// Validate properties of the knowledge base as a whole
+fn global_validate(entries: EntriesMap) -> Errors {
+    let mut errors = Vec::new();
+    errors.extend(validate_unique_platform_issues(&entries).into_iter());
+    errors
+}
+
+/// Validate knowledge base entries
+fn validate(root_path: &Path) -> Result<Errors, Box<dyn Error>> {
+    let mut errors: Errors = Vec::new();
+    let (entries, file_errors) = load_and_validate_files(root_path)?;
+    errors.extend(file_errors.into_iter());
+    errors.extend(global_validate(entries).into_iter());
     Ok(errors)
 }
 


### PR DESCRIPTION
This splits validation into a few more clearly defined stages and adds
some additional validators:

* First we read the data files to a string and validate any textual
properties of the file.
* Then we validate against the schema and, if that succeeds, convert
the data into an internal representation.
* Then we collect the internal representations of all files and
validate any global properties e.g. uniqueness of certain fields.

This design depends on us being able to load all the data at once;
that should continue to be true for a long time, but in case it isn't
we can change the approach for cross-file validation.

Two specific new validation steps are added:
* Check for trailing whitespace in files.
* Check for globally unique issue URL (i.e. we can't have multiple kb
entries for a single platform bug).