### PR TITLE
Remove dup breakage URL in Sidebar item

### DIFF
--- a/data/sidebar.yml
+++ b/data/sidebar.yml
@@ -17,7 +17,6 @@ solutions:
 references:
   breakage:
     - https://github.com/webcompat/web-bugs/issues/11622
-    - https://github.com/webcompat/web-bugs/issues/11622
     - https://github.com/webcompat/web-bugs/issues/55685
     - https://github.com/webcompat/web-bugs/issues/67848
     - https://github.com/webcompat/web-bugs/issues/106830


### PR DESCRIPTION
Just removing a dupped URL in an existing entry