### PR TITLE
Follow up for #34 - Add `Unknown` to the `UserBaseImpact` enum.

### DIFF
--- a/tools/kbcheck/src/entry.rs
+++ b/tools/kbcheck/src/entry.rs
@@ -16,6 +16,7 @@ pub enum UserBaseImpact {
     Large,
     Medium,
     Small,
+    Unknown,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]


### PR DESCRIPTION
In #34, the `unknown` value was added to the schema, but not the Rust representation. Because of that, validation of entries with `unknown` would fail with

```
data/geckoview-window-print.yml - unknown variant `unknown`, expected one of `large`, `medium`, `small`
```

---

I'll note that this confused me a bit. I thought I messed up a rebase or something, and even double-checked that rustc doesn't end up embedding the schema during compile time or whatever. The error message shown when using an invalid value looks very similar:

```
data/geckoview-window-print.yml - "unknown" is not one of ["small","medium","large"]
```

and I wonder if we can prefix error messages with "Validation error:" and "Deserialization error:" or something.