### PR TITLE
Add a notes field to the schema

### DIFF
--- a/schemas/entry.schema.json
+++ b/schemas/entry.schema.json
@@ -20,6 +20,10 @@
       "type": "string",
       "enum": ["small", "medium", "large", "unknown"]
     },
+    "notes": {
+      "description": "Additional information about the priority of the issue, including reasoning for the `severity` and `user_base_impact` settings, where that isn't obvious.",
+      "type": "string"
+    },
     "tags": {
       "description": "List of tags to attached to this issue",
       "type": "array",

--- a/tools/kbcheck/src/entry.rs
+++ b/tools/kbcheck/src/entry.rs
@@ -49,6 +49,7 @@ pub struct Entry {
     pub title: String,
     pub severity: Severity,
     pub user_base_impact: Option<UserBaseImpact>,
+    pub notes: Option<String>,
     #[serde(default)]
     pub tags: Vec<String>,
     #[serde(default)]


### PR DESCRIPTION
This is primarilly intended for additional information that justifies the
severity and user_base_impact settings.