### PR TITLE
Add entry about different Permission Policies for Web Share API usage in iFrames

### DIFF
--- a/data/webshare-permission-policy.yml
+++ b/data/webshare-permission-policy.yml
@@ -1,0 +1,30 @@
+title: Breakage caused by permission policies for Web Share API usage in iFrames
+tags:
+  - permissions
+  - webshare
+
+severity: normal
+user_base_impact: medium
+
+symptoms:
+  - Users are unable to use a Share button on websites
+  - Users are unable to use YouTube's share button for embedded videos
+
+solutions:
+  notes:
+    - While the standard is not finished yet, adding the `allow="web-share"` attrubute to the iFrame makes it work in all browsers.
+  interventions:
+    - https://github.com/mozilla-extensions/webcompat-addon/blob/8b3865cb772b2596549705d11ed3aa1a376c60cd/src/data/injections.js#L572-L581
+
+references:
+  breakage:
+    - https://github.com/webcompat/web-bugs/issues/68473
+    - https://github.com/webcompat/web-bugs/issues/88374
+    - https://github.com/webcompat/web-bugs/issues/105859
+    - https://github.com/webcompat/web-bugs/issues/106938
+    - https://github.com/webcompat/web-bugs/issues/107286
+  platform_issues:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1737541
+  standards_discussions:
+    - https://github.com/w3c/web-share/issues/233
+    - https://github.com/w3c/web-share/pull/234


### PR DESCRIPTION
This closes #62.