### PR TITLE
Fixes #81 - Extend the prefill script to extract detailed information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 target/
 
 .mypy_cache/
+.env

--- a/docs/generate-yml.md
+++ b/docs/generate-yml.md
@@ -3,7 +3,14 @@
 The script will generate a yml file in the `data` directory and prefill title, breakage reports from webcompat and fenix repository, as well as
 platform links (the original bugzilla bug and any others from bugs.chromium.org or bugs.webkit.org).
 
-It can be run the following way:
+Before running the script, generate a new GitHub token on https://github.com/settings/tokens
+and create an .env file in the root directory with the following content:
+
+```
+GITHUB_TOKEN = '<your token>'
+```
+
+The script can be run the following way:
 
 ```
 python3 -m venv env

--- a/docs/generate-yml.md
+++ b/docs/generate-yml.md
@@ -3,18 +3,28 @@
 The script will generate a yml file in the `data` directory and prefill title, breakage reports from webcompat and fenix repository, as well as
 platform links (the original bugzilla bug and any others from bugs.chromium.org or bugs.webkit.org).
 
-Before running the script, generate a new GitHub token on https://github.com/settings/tokens
-and create an .env file in the root directory with the following content:
-
-```
-GITHUB_TOKEN = '<your token>'
-```
-
 The script can be run the following way:
 
 ```
 python3 -m venv env
 source env/bin/activate
 pip install -r requirements.txt
-python3 ./tools/scripts/generate.py --bug_id=<bug_id>
+python3 ./tools/scripts/generate.py --create=<bug_id> --write
+```
+This will generate an entry file for the provided bugzilla bug id.
+
+To add detailed breakage section to an existing entry (for example, marquee):
+
+```
+python3 ./tools/scripts/generate.py --get-breakage-details=data/marquee.yml --write
+```
+
+
+*Optional:*
+
+To bypass GitHub limit of 60 requests per hour for unauthenticated users, generate a new GitHub token on https://github.com/settings/tokens
+and create an .env file in the root directory with the following content:
+
+```
+GITHUB_TOKEN = '<your token>'
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 mypy==0.971
 pre-commit==2.20.0
+python-dotenv==0.20.0
 python-slugify==6.1.2
-pyyaml==6.0.0
+ruamel.yaml==0.17.21
 requests==2.28.1

--- a/tools/scripts/generate.py
+++ b/tools/scripts/generate.py
@@ -1,11 +1,14 @@
-import requests
 import argparse
-import yaml
+import ruamel.yaml as yaml
 import os
+
 from logging import INFO, basicConfig, getLogger
 from pathlib import Path
 from slugify import slugify
 from urllib.parse import urlparse
+
+from helpers.issue import Issue
+from helpers.bugzilla import fetch_bug_by_id
 
 basicConfig(level=INFO)
 logger = getLogger("generate_script")
@@ -14,7 +17,6 @@ cwd = os.getcwd()
 DATA_PATH = os.path.join(cwd, 'data')
 
 BUGZILLA_URL = "https://bugzilla.mozilla.org/show_bug.cgi?id="
-BUGZILLA_API = "https://bugzilla.mozilla.org/rest/bug/"
 
 BREAKAGE_STR = ["webcompat", "mozilla-mobile"]
 PLATFORM_STR = ["bugs.chromium.org", "bugs.webkit.org"]
@@ -22,39 +24,34 @@ PLATFORM_STR = ["bugs.chromium.org", "bugs.webkit.org"]
 YAML_FILE_EXT = ("*.yaml", "*.yml")
 
 
-def fetch_bug_by_id(bug_id: str) -> dict:
-    url = BUGZILLA_API + bug_id
-    params = {"include_fields": "summary,see_also"}
-    response = requests.get(url, params=params)
-    response.raise_for_status()
-    result = response.json()
-    return result["bugs"][0]
+def generate_breakage_report(issue_url: str) -> dict:
+    issue = Issue(issue_url)
+    report = issue.generate_report()
+    return report
 
 
-def split_see_also_by_type(see_also_list: list, bug_id: str) -> dict:
-    lists = {
-        "breakage": [f"{BUGZILLA_URL}{bug_id}#c0"],
-        "platform": [BUGZILLA_URL + bug_id]
-    }
+def split_see_also_by_type(see_also_list: list, bug_id: str) -> tuple:
+    breakage = []
+    platform = [BUGZILLA_URL + bug_id]
 
     for item in see_also_list:
         if any(bs in item for bs in BREAKAGE_STR):
-            lists["breakage"].append(item)
+            breakage.append(generate_breakage_report(item))
 
         if any(ps in item for ps in PLATFORM_STR):
-            lists["platform"].append(item)
+            platform.append(item)
 
-    return lists
+    return breakage, platform
 
 
 def build_obj(bug_id: str) -> dict:
     bug = fetch_bug_by_id(bug_id)
-    lists = split_see_also_by_type(bug["see_also"], bug_id)
+    breakage, platform = split_see_also_by_type(bug["see_also"], bug_id)
     data = {
         "title": bug["summary"],
         "references": {
-            "breakage": lists["breakage"],
-            "platform_issues": lists["platform"]
+            "breakage": breakage,
+            "platform_issues": platform
         }
     }
 
@@ -104,8 +101,11 @@ def build_yml(bug_id: str) -> None:
         logger.error(f"A file with the same name already exists: `{path}`, please edit it instead.")
         return
 
+    y = yaml.YAML()
+    y.indent(mapping=2, sequence=4, offset=2)
+
     with open(path, 'w') as f:
-        yaml.dump(data, f, sort_keys=False, default_flow_style=False)
+        y.dump(data, f)
         logger.info(f"{filename}.yml file was created for bug {bug_id} ({title})")
 
 

--- a/tools/scripts/generate.py
+++ b/tools/scripts/generate.py
@@ -92,7 +92,7 @@ def create(bug_id: str, write: bool) -> Optional[str]:
         logger.error(
             f"A duplicate bug url has been found in {','.join(duplicates)}"
         )
-        return
+        return None
 
     data = build_obj(bug_id)
     title = data["title"]
@@ -102,7 +102,7 @@ def create(bug_id: str, write: bool) -> Optional[str]:
 
     if os.path.exists(path):
         logger.error(f"A file with the same name already exists: `{path}`, please edit it instead.")
-        return
+        return None
 
     output_path = path if write else None
     write_yml(data, output_path)
@@ -189,6 +189,7 @@ def main() -> None:
             logger.error("Couldn't open editor, please set EDITOR environment variable")
         else:
             subprocess.call([editor, path])
+
 
 if __name__ == "__main__":
     main()

--- a/tools/scripts/helpers/bugzilla.py
+++ b/tools/scripts/helpers/bugzilla.py
@@ -1,0 +1,12 @@
+import requests
+
+BUGZILLA_API = "https://bugzilla.mozilla.org/rest/bug/"
+
+
+def fetch_bug_by_id(bug_id: str) -> dict:
+    url = BUGZILLA_API + bug_id
+    params = {"include_fields": "summary,see_also"}
+    response = requests.get(url, params=params)
+    response.raise_for_status()
+    result = response.json()
+    return result["bugs"][0]

--- a/tools/scripts/helpers/github.py
+++ b/tools/scripts/helpers/github.py
@@ -1,0 +1,36 @@
+import logging
+import os
+import requests
+
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+logger = logging.getLogger(__name__)
+
+
+class GitHub:
+    def get_headers(self) -> dict:
+        token = os.environ.get("GITHUB_TOKEN")
+        assert token, "GitHub token is not found."
+        return {"Authorization": "token {}".format(token)}
+
+    def fetch_timeline(self, timeline_url: str) -> list:
+        params = {
+            "per_page": 100,
+        }
+        response = requests.get(timeline_url, params=params, headers=self.get_headers())
+        response.raise_for_status()
+        timeline_raw = response.json()
+        return timeline_raw
+
+    def fetch_issue_by_number(self, owner: str, repo: str, issue_number: str) -> dict:
+        url = f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}"
+        logger.info(f"Fetching issue: {url}")
+        response = requests.get(url, headers=self.get_headers())
+        response.raise_for_status()
+        issue_raw = response.json()
+
+        timeline = self.fetch_timeline(url + "/timeline")
+        issue_raw.update({"timeline": timeline})
+
+        return issue_raw

--- a/tools/scripts/helpers/github.py
+++ b/tools/scripts/helpers/github.py
@@ -11,7 +11,10 @@ logger = logging.getLogger(__name__)
 class GitHub:
     def get_headers(self) -> dict:
         token = os.environ.get("GITHUB_TOKEN")
-        assert token, "GitHub token is not found."
+
+        if not token:
+            return {}
+
         return {"Authorization": "token {}".format(token)}
 
     def fetch_timeline(self, timeline_url: str) -> list:

--- a/tools/scripts/helpers/github.py
+++ b/tools/scripts/helpers/github.py
@@ -17,23 +17,36 @@ class GitHub:
 
         return {"Authorization": "token {}".format(token)}
 
+    def fetch_data(self, url: str, params: dict = None) -> tuple:
+        response = requests.get(url, params=params, headers=self.get_headers())
+        response.raise_for_status()
+        data = response.json()
+
+        return data, response.links
+
     def fetch_timeline(self, timeline_url: str) -> list:
         params = {
             "per_page": 100,
+            "page": 1
         }
-        response = requests.get(timeline_url, params=params, headers=self.get_headers())
-        response.raise_for_status()
-        timeline_raw = response.json()
-        return timeline_raw
+
+        data, response_links = self.fetch_data(
+            url=timeline_url, params=params
+        )
+
+        while "next" in response_links.keys():
+            next_page_timeline, response_links = self.fetch_data(
+                response_links["next"]["url"]
+            )
+            data += next_page_timeline
+
+        return data
 
     def fetch_issue_by_number(self, owner: str, repo: str, issue_number: str) -> dict:
         url = f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}"
         logger.info(f"Fetching issue: {url}")
-        response = requests.get(url, headers=self.get_headers())
-        response.raise_for_status()
-        issue_raw = response.json()
 
-        timeline = self.fetch_timeline(url + "/timeline")
-        issue_raw.update({"timeline": timeline})
+        issue_data = self.fetch_data(url)[0]
+        issue_data["timeline"] = self.fetch_timeline(url + "/timeline")
 
-        return issue_raw
+        return issue_data

--- a/tools/scripts/helpers/issue.py
+++ b/tools/scripts/helpers/issue.py
@@ -1,0 +1,162 @@
+from dataclasses import dataclass
+from typing import List
+
+from helpers.github import GitHub
+from helpers.utils import extract_url, to_datetime, extract_issue_number
+
+WEBCOMPAT_URL = "https://webcompat.com/issues/"
+
+BROWSER_MAP = {
+    "browser-fenix": "mobile",
+    "browser-firefox-mobile": "mobile",
+    "browser-focus-geckoview": "mobile",
+    "browser-android-components": "mobile",
+    "browser-firefox-ios": "mobile",
+    "browser-firefox": "desktop"
+}
+
+RESOLVED_MAP = {
+    "fixed": "site_fixed",
+    "worksforme": "site_changed",
+    "intervention": "site_changed"
+}
+
+SEVERITY_MAP = {
+    "severity-minor": "minor_visual",
+    "severity-important":
+        "Suggested impact is `feature_broken` or `significant_visual` as issue has severity-important label.",
+    "severity-critical": "Suggested impact is `site_broken` or `feature_broken` as issue has severity-critical label.",
+    "type-unsupported": "unsupported_message"
+}
+
+TRACKED_MILESTONES = [
+    "needsdiagnosis",
+    "duplicate",
+    "moved",
+    "contactready",
+    "needscontact",
+    "sitewait"
+]
+
+
+@dataclass
+class WebcompatIssue:
+    body: str
+    breakage_url: str
+    number: int
+    title: str
+    labels: List[str]
+    milestone: str
+    timeline: List[dict]
+
+    @classmethod
+    def from_dict(cls, issue: dict):
+        original_labels = issue.get("labels", [])
+        labels = [label["name"] for label in original_labels]
+        issue_body = issue["body"]
+        breakage_url = extract_url(issue_body)
+
+        milestone = ""
+        if issue.get("milestone"):
+            milestone = issue["milestone"]["title"]
+
+        return cls(body=issue_body,
+                   breakage_url=breakage_url,
+                   number=issue["number"],
+                   title=issue["title"],
+                   labels=labels,
+                   milestone=milestone,
+                   timeline=issue["timeline"])
+
+    def build_canonical_url(self) -> str:
+        return WEBCOMPAT_URL + str(self.number)
+
+    def get_platform(self) -> list:
+        browser = []
+        for label in self.labels:
+            if label in BROWSER_MAP:
+                browser.append(BROWSER_MAP[label])
+
+        if len(browser) >= 2:
+            browser = ['all']
+
+        return browser
+
+    def get_last_reproduced(self) -> str:
+        if self.milestone in TRACKED_MILESTONES:
+            for timeline_item in self.timeline:
+                if (timeline_item["event"] == "milestoned"
+                        and timeline_item["milestone"]["title"] == self.milestone):
+                    return to_datetime(timeline_item["created_at"]).strftime('%Y-%m-%d')
+
+        return ""
+
+    def estimate_impact(self) -> str:
+        if "type-unsupported" in self.labels:
+            return SEVERITY_MAP["type-unsupported"]
+
+        severity_label = [label for label in self.labels if label.startswith('severity-')]
+
+        if severity_label:
+            return SEVERITY_MAP[severity_label[0]]
+
+        return "Can't estimate impact, please enter it manually."
+
+    def generate_report(self) -> dict:
+        is_fixed = False
+
+        report = {
+            "url": self.build_canonical_url(),
+            "site": self.breakage_url,
+            "platform": self.get_platform()
+        }
+
+        if self.milestone in RESOLVED_MAP.keys():
+            is_fixed = True
+            report["resolution"] = RESOLVED_MAP[self.milestone]
+
+        if "sitepatch-applied" in self.labels:
+            is_fixed = True
+            report["intervention"] = "Intervention is detected for this issue. Please locate it manually."
+            report["resolution"] = RESOLVED_MAP["intervention"]
+
+        if is_fixed:
+            report["impact"] = "minor_visual"
+            report["affects_users"] = "few"
+        else:
+            report["impact"] = self.estimate_impact()
+            report["affects_users"] = f"Check the issue for more details: {self.title}."
+
+            reproduced_date = self.get_last_reproduced()
+            if reproduced_date:
+                report["last_reproduced"] = reproduced_date
+
+        return report
+
+
+class Issue:
+    def __init__(self, url) -> None:
+        self.url = url
+
+        if "webcompat" in url:
+            self.type = "webcompat"
+        elif "mozilla-mobile" in url:
+            self.type = "fenix"
+
+    def generate_report(self) -> dict:
+        report = {
+            "url": self.url
+        }
+
+        if self.type == "webcompat":
+            issue_number = extract_issue_number(self.url)
+            github = GitHub()
+            issue_data = github.fetch_issue_by_number(
+                "webcompat",
+                "web-bugs",
+                issue_number
+            )
+            wc_issue = WebcompatIssue.from_dict(issue_data)
+            report = wc_issue.generate_report()
+
+        return report

--- a/tools/scripts/helpers/issue.py
+++ b/tools/scripts/helpers/issue.py
@@ -17,8 +17,7 @@ BROWSER_MAP = {
 
 RESOLVED_MAP = {
     "fixed": "site_fixed",
-    "worksforme": "site_changed",
-    "intervention": "site_changed"
+    "worksforme": "site_changed"
 }
 
 SEVERITY_MAP = {
@@ -103,8 +102,6 @@ class WebcompatIssue:
         return "Can't estimate impact, please enter it manually."
 
     def generate_report(self) -> dict:
-        is_fixed = False
-
         report = {
             "url": self.build_canonical_url(),
             "site": self.breakage_url,
@@ -112,24 +109,17 @@ class WebcompatIssue:
         }
 
         if self.milestone in RESOLVED_MAP.keys():
-            is_fixed = True
             report["resolution"] = RESOLVED_MAP[self.milestone]
 
         if "sitepatch-applied" in self.labels:
-            is_fixed = True
             report["intervention"] = "Intervention is detected for this issue. Please locate it manually."
-            report["resolution"] = RESOLVED_MAP["intervention"]
 
-        if is_fixed:
-            report["impact"] = "minor_visual"
-            report["affects_users"] = "few"
-        else:
-            report["impact"] = self.estimate_impact()
-            report["affects_users"] = f"Check the issue for more details: {self.title}."
+        report["impact"] = self.estimate_impact()
+        report["affects_users"] = f"Check the issue for more details: {self.title}."
 
-            reproduced_date = self.get_last_reproduced()
-            if reproduced_date:
-                report["last_reproduced"] = reproduced_date
+        reproduced_date = self.get_last_reproduced()
+        if reproduced_date:
+            report["last_reproduced"] = reproduced_date
 
         return report
 

--- a/tools/scripts/helpers/issue.py
+++ b/tools/scripts/helpers/issue.py
@@ -5,6 +5,7 @@ from helpers.github import GitHub
 from helpers.utils import extract_url, to_datetime, extract_issue_number
 
 WEBCOMPAT_URL = "https://webcompat.com/issues/"
+MISSING_PLACEHOLDER = "[missing]"
 
 BROWSER_MAP = {
     "browser-fenix": "mobile",
@@ -23,9 +24,8 @@ RESOLVED_MAP = {
 
 SEVERITY_MAP = {
     "severity-minor": "minor_visual",
-    "severity-important":
-        "Suggested impact is `feature_broken` or `significant_visual` as issue has severity-important label.",
-    "severity-critical": "Suggested impact is `site_broken` or `feature_broken` as issue has severity-critical label.",
+    "severity-important": MISSING_PLACEHOLDER,
+    "severity-critical": MISSING_PLACEHOLDER,
     "type-unsupported": "unsupported_message"
 }
 
@@ -100,7 +100,7 @@ class WebcompatIssue:
         if severity_label:
             return SEVERITY_MAP[severity_label[0]]
 
-        return "Can't estimate impact, please enter it manually."
+        return MISSING_PLACEHOLDER
 
     def generate_report(self) -> dict:
         report = {
@@ -116,7 +116,7 @@ class WebcompatIssue:
             report["intervention"] = "Intervention is detected for this issue. Please locate it manually."
 
         report["impact"] = self.estimate_impact()
-        report["affects_users"] = f"Check the issue for more details: {self.title}."
+        report["affects_users"] = MISSING_PLACEHOLDER
 
         reproduced_date = self.get_last_reproduced()
         if reproduced_date:

--- a/tools/scripts/helpers/issue.py
+++ b/tools/scripts/helpers/issue.py
@@ -17,7 +17,8 @@ BROWSER_MAP = {
 
 RESOLVED_MAP = {
     "fixed": "site_fixed",
-    "worksforme": "site_changed"
+    "worksforme": "site_changed",
+    "invalid": "site_changed"
 }
 
 SEVERITY_MAP = {

--- a/tools/scripts/helpers/utils.py
+++ b/tools/scripts/helpers/utils.py
@@ -1,0 +1,33 @@
+import re
+from datetime import datetime
+
+
+def extract_url(issue_body: str) -> str:
+    """Extract the URL for an issue from WebCompat.
+
+    URL in webcompat.com bugs follow this pattern:
+    **URL**: https://example.com/foobar
+    """
+    url_pattern = re.compile(r"\*\*URL\*\*\: (.+)")
+    url_match = re.search(url_pattern, issue_body)
+    if url_match:
+        url = url_match.group(1).strip()
+        if not url.startswith(("http://", "https://")):
+            url = "http://%s" % url
+    else:
+        url = ""
+    return url
+
+
+def to_datetime(date_str: str) -> datetime:
+    """Convert date to datetime object.
+
+    date_str: 2015-07-28T09:25:03Z
+    """
+    normalized_date_str = date_str.replace("Z", "+00:00")
+    return datetime.fromisoformat(normalized_date_str)
+
+
+def extract_issue_number(url_str: str) -> str:
+    num = re.findall('[0-9]+', url_str)
+    return num[0]


### PR DESCRIPTION
This is an attempt to prefill some of the fields, based on the following:

- site
   Parse issue body to get the site url.

- platform: 
  Extract `browser-` and potentially `os-` labels.

- last_reproduced: 
   If the issue is in `needsdiagnosis`,`duplicate`, `moved`, `contactready`, `needscontact`, `sitewait` milestone, we can extract the date it was moved to it, from [timelines api](https://api.github.com/repos/webcompat/web-bugs/issues/106830/timeline). 
If the issue is in `worksforme` or `fixed` milestone, we can skip this field?

- intervention
   **Could check for `sitepatch-applied` label, but the intervention url needs to be located manually**

- impact:
   At least two of the options can be added based on the labels - `unsupported_message` (based on `type-unsupported`) and `minor_visual` (based on `severity-minor`). 
  **"site_broken", "feature_broken", "significant_visual" need to be checked manually**

- affects_users:
   **This is tricky, need to read through report. Sometimes it's possible to know just by looking at the issue title though :)** 

- resolution: 
`site_fixed` if issue is in `fixed` milestone, `site_changed` if the issue is `worksforme` milestones or has an intervention
