### PR TITLE
Add env/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 # Build output from the kbcheck tool
 target/
 
-
 # Python
-.mypy_cache/
 .env
+.mypy_cache/
+env/


### PR DESCRIPTION
[`docs/generate-yml.md`](https://github.com/webcompat/knowledge-base/blob/39e639a08adb08ea6bdede5b6a28f67870612952/docs/generate-yml.md) suggests to generate a venv with `python3 -m venv env`, which makes sense.

However, we should probably add that venv to the `.gitignore` so we don't have to actively avoid committing it. :)