### PR TITLE
Add `__pycache__` directories to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 target/
 
 # Python
+__pycache__/
 .env
 .mypy_cache/
 env/


### PR DESCRIPTION
Running the `generate` Python script generates a `__pycache__` folder with a bunch of `.pyc` files for me. Doesn't look like the kind of thing that should be committed. :)